### PR TITLE
Release/0.2.0

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,10 +1,10 @@
-FROM node:argon
+FROM pinkhippos/base-development
 
 WORKDIR /usr/ph-todo-api
 ADD ./build ./build
 ADD ./package.json .
 ADD yarn.lock .
 
-RUN npm i -g nodemon yarn ; yarn install
+RUN yarn install
 
 WORKDIR /usr/ph-todo-api/build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Pink Hippos API server
-#### v0.1.0
+#### v0.2.0

--- a/src/todo_api/add_todo.coffee
+++ b/src/todo_api/add_todo.coffee
@@ -2,7 +2,7 @@ act = require "#{__dirname}/../seneca/act"
 send_error = require "#{__dirname}/../helpers/send_error"
 
 module.exports = (req, res)->
-  {todo} = req.body
+  todo = req.body
   # {id, username} = req.auth_payload
   # todo.author = id
   add_opts =
@@ -10,14 +10,8 @@ module.exports = (req, res)->
     cmd: 'add_todo'
     new_todo: todo
   act add_opts
-  .catch send_error res
   .then (new_todo)->
-    # log_opts =
-    #   role: 'util'
-    #   cmd: 'log'
-    #   service: 'todo_api'
-    #   message: "New todo added for #{username}."
-    # act log_opts
     res
       .status 201
       .json new_todo
+  .catch send_error res

--- a/src/todo_api/get_todos.coffee
+++ b/src/todo_api/get_todos.coffee
@@ -14,9 +14,10 @@ module.exports = (req, res)->
 
   # Execute the action
   act get_opts
-  .catch send_error res
   .then (todos)->
     # Send all the retrieved todos
     res
       .status 200
       .json todos
+  .catch send_error res
+  

--- a/src/todo_api/update_todo.coffee
+++ b/src/todo_api/update_todo.coffee
@@ -4,8 +4,9 @@ send_error = require "#{__dirname}/../helpers/send_error"
 module.exports = (req, res)->
   update_opts =
     role: 'todo'
-    cmd: 'get_todos'
+    cmd: 'update_todo'
     id: req.params.id
+    changes: req.body
   act update_opts
   .catch send_error res
   .then (updated_todo)->


### PR DESCRIPTION
CRUD requests to `/api/todos` and `/api/todo/:id` are functional
<img width="638" alt="screen shot 2017-02-01 at 7 51 51 am" src="https://cloud.githubusercontent.com/assets/9676018/22514178/50061868-e853-11e6-933c-3518540d5f86.png">
